### PR TITLE
手動トリガーになるように設定

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -3,11 +3,13 @@
 
 name: Node.js CI
 
-on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+# on:
+#   push:
+#     branches: [ "main" ]
+#   pull_request:
+#     branches: [ "main" ]
+
+on: [ workflow_dispatch ]
 
 jobs:
   build:

--- a/.github/workflows/npm-publish-github-packages.yml
+++ b/.github/workflows/npm-publish-github-packages.yml
@@ -1,8 +1,0 @@
-name: learn-github-actions
-on: [push]
-
-jobs:
-  check-bats-version:
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "Hello World"


### PR DESCRIPTION
CI/CDのパイプラインを作成するにあったって、メインブランチにpushすることそれ自体をトリガーとしていたが、pushするとうるさくなってしまうため、ここで保留するためにも基本成功したらトリガーを手動、つまり[ workflow_dispatch ]を指定する。